### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,19 +6,19 @@
 # Datatypes             (KEYWORD1)
 #######################################
 
-TalkingLED               KEYWORD1
+TalkingLED	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin                    KEYWORD2
-message                  KEYWORD2
-sequence                 KEYWORD2
-update                   KEYWORD2
-delay                    KEYWORD2
-waitEnd                  KEYWORD2
-set                      KEYWORD2
+begin	KEYWORD2
+message	KEYWORD2
+sequence	KEYWORD2
+update	KEYWORD2
+delay	KEYWORD2
+waitEnd	KEYWORD2
+set	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords